### PR TITLE
Fade in feature

### DIFF
--- a/public/scripts/client.js
+++ b/public/scripts/client.js
@@ -19,6 +19,19 @@ const observer = new IntersectionObserver(([{isIntersecting}], _) => { //Dit geb
 
 observer.observe(header2) // Kijk naar header2
 
+
+// Code voor fade-in effect
+document.querySelectorAll('.fade-in').forEach(function(fadeElement) {
+    new IntersectionObserver(function(entries, observer) {
+        entries.forEach(function(entry) {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('visible');
+                observer.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.1 }).observe(fadeElement);
+});
+
 //Code voor post form
 forms.forEach(function(form) {
   form.addEventListener('submit', function (event) {

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -281,6 +281,21 @@ header:has(.categories-nav.closed) .menu-button {
 }
 /* #endregion Header */
 
+/* #region fadein */
+@media (scripting: enabled) {
+  .fade-in {
+      opacity: 0;
+      transform: translateY(20px);
+      transition: opacity 0.6s, transform 0.6s;
+  }
+
+  .fade-in.visible {
+      opacity: 1;
+      transform: translateY(0);
+  }
+}
+/* #endregion fadein */
+
 /* #region Media */
 @media only screen and (max-width: 768px) {
   .header2 {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -12,7 +12,7 @@
     <div class="main-container">
       <a class="article-link" href="artikel/<%= featured[0].slug%>">
         <article class="main-article">
-          <div class="article-content-container">
+          <div class="article-content-container fade-in">
             <div class="article-date-container">
               <p class="article-date"><%= featured[0].date %></p>
             </div>
@@ -26,7 +26,7 @@
             </div>
           </div>
 
-          <div class="article-image-container">
+          <div class="article-image-container fade-in">
             <img class="article-featured-image"
                 src="<%= featured[0].yoast_head_json.og_image[0].url%>"
                 width="<%= featured[0].yoast_head_json.og_image[0].width%>"
@@ -42,7 +42,7 @@
     <div class="sub-article-container">
     <% for (var i = 1; i <= 3; i++) { %>
       <a class="article-link" href="artikel/<%= featured[i].slug%>">
-        <article class="sub-article">
+        <article class="sub-article fade-in">
           <div class="sub-article-featured-image-container">
             <img loading="lazy" class="sub-article-featured-image"
             src="<%= featured[i].yoast_head_json.og_image[0].url %>"
@@ -83,7 +83,7 @@
     <div class="sub-article-container">
     <% posts[index].forEach(article => { %>
       <a class="article-link" href="artikel/<%= article.slug %>">
-        <article class="sub-article">
+        <article class="sub-article fade-in">
           <div class="sub-article-featured-image-container">
             <img loading="lazy" class="sub-article-featured-image"
               src="<%= article.yoast_head_json.og_image[0].url %>"


### PR DESCRIPTION
Ik heb een fade in effect gemaakt op artikelen op de voorpagina. Als je de naar de voorpagina van red pers gaat dan zie je dat artikelen in laden met een fade in effect op het moment dat ze in de viewport van de gebruiker komen. Als de gebruiker naar beneden scrollt ziet de gebruiker dat artikelen steeds in laden met het  fade in effect. De fade in effect is dat de opacity van het artikel van 0 opacity naar 1 opacity gaat met een snelheid van 0.6s.

Ik heb het eerst geschetst:

![20240524_102321](https://github.com/Khdulkadir/pleasurable-ui/assets/144004145/f7f808b6-5474-4f94-8b59-e1a0fdf26fd6)

En zo ziet het eruit op de pagina:

https://github.com/Khdulkadir/pleasurable-ui/assets/144004145/27026d99-7fbb-4e33-9960-5f6253cd84c8

Ik heb mij tijdens het bouwen gehouden aan de [code afspraken](https://github.com/Khdulkadir/pleasurable-ui/wiki/1.-analyseren#code-conventies) die we hebben gemaakt.

Verder is deze feature gebouwd met progressive enhancement in gedachten. Als de gebruiker geen javascript heeft dan werkt de pagina zoals normaal maar zonder de pleasurable ui feature "fade in".

Fixes #28 